### PR TITLE
Point to code of conduct in the agreements repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Silicon Labs Community Terms of Use
 
-Please read the full Terms of Use and Code of Conduct in the [agreements-and-guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines) repository: [Code of Conduct](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/code_of_conduct.md)
+Please read the full Terms of Use and Code of Conduct in [agreements-and-guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines) repository: [Code of Conduct](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/code_of_conduct.md)


### PR DESCRIPTION
Related to #31 issue. 

This is how it will look like in the repo:
![image](https://github.com/user-attachments/assets/9a991535-60e2-4970-a10e-4a8b7dfcbd53)

