### PR TITLE
IOT_DS-8566: fix CLA trigger condition and enable CLA workflow triggers

### DIFF
--- a/.github/workflows/01-CLA-Assistant.yml
+++ b/.github/workflows/01-CLA-Assistant.yml
@@ -1,12 +1,9 @@
 name: 01-CLA-Assistant
-## This workflow is used only for public repositories
-## uncomment the other trigger conditions for public repositories
-
 on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened,closed,synchronize,reopened]
+    types: [opened, closed, synchronize, reopened]
 
 permissions:
   actions: write
@@ -16,6 +13,12 @@ permissions:
 
 jobs:
   CLAAssistant:
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       (github.event.comment.body == 'recheck' ||
+        contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')))
     runs-on: ubuntu-24.04
     steps:
       - name: Create CLA Assistant Lite bot token
@@ -28,7 +31,6 @@ jobs:
           repositories: contributor-license-agreements
 
       - name: "CLA Assistant"
-        if: ${{ contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA') }} || github.event_name == 'pull_request_target'
         uses: SiliconLabsSoftware/action-cla-assistant@silabs_flavour_v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,7 +38,7 @@ jobs:
         with:
           path-to-signatures: "cla_signatures_db.json"
           path-to-document: "https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md"
-          branch: 'cla-database'
+          branch: "cla-database"
           allowlist: silabs-*,bot*
           # the following are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: "SiliconLabsInternal"


### PR DESCRIPTION
This PR updates the CLA Assistant workflow trigger condition and enables trigger events for CLA processing.

Changes:
- Replace the CLA step condition with a guarded expression that handles `pull_request_target` and qualifying `issue_comment` events
- Enable `issue_comment` and `pull_request_target` triggers when they were commented out

Ticket: IOT_DS-8566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust GitHub Actions trigger/if conditions for CLA processing; impact is limited to whether/when the workflow runs.
> 
> **Overview**
> Fixes the CLA Assistant GitHub Actions workflow so it runs for `pull_request_target` events and only for qualifying `issue_comment` events (PR comments containing `recheck` or the CLA signing text).
> 
> Moves the comment-body check from the step level to a guarded job-level `if` (also ensuring the comment is on a PR), and cleans up minor YAML formatting (event types list and quoting for `branch`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7dc438cad6cc11fc563634f1087824716acf4c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->